### PR TITLE
ci(workflows): sync with fredrikaverpil/github

### DIFF
--- a/.github/workflows/unmanaged-lua.yml
+++ b/.github/workflows/unmanaged-lua.yml
@@ -1,0 +1,16 @@
+# SAFE TO CUSTOMIZE - This file is copied once and not overwritten during sync
+# Source: https://github.com/fredrikaverpil/github
+name: lua
+
+on:
+  workflow_dispatch:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  ci:
+    uses: fredrikaverpil/github/.github/workflows/lua.yml@main
+    with:
+      os-versions: '["ubuntu-latest"]'


### PR DESCRIPTION
This PR syncs the GitHub repo with CI workflows from the [fredrikaverpil/github](https://github.com/fredrikaverpil/github) repository.