### PR TITLE
ci(dependabot): sync with fredrikaverpil/github

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,13 +4,27 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "/"
+    directories: ["/", ".github/actions/*/*.yml", ".github/actions/*/*.yaml"]
     schedule:
       interval: "weekly"
       day: "monday"
     groups:
       github-actions:
         patterns: ["*"]
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "cargo"
+    directories:
+      - tools
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      cargo-minor-patch:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
     open-pull-requests-limit: 10
     labels:
       - "dependencies"


### PR DESCRIPTION
This PR syncs the GitHub repo with a generated `dependabot.yml` from the [fredrikaverpil/github](https://github.com/fredrikaverpil/github) repository.